### PR TITLE
Avoid null snap in Marketo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,21 @@ Extract the macaroon and discharge from the generated file and update the secret
 ```bash
 kubectl edit secret snapcraft-monthly-stats-email --namespace production
 ```
+
+## Run the project
+
+1. You will need to create a `.env.local` file in the root of the project with the following secrets:
+
+    ```
+    WEBTEAM_ACCOUNT_EMAIL
+    WEBTEAM_ROOT_MACAROON
+    WEBTEAM_DISCHARGE_MACAROON
+    MARKETO_REST_DOMAIN
+    MARKETO_CLIENT_ID
+    MARKETO_SECRET
+    SENTRY_DSN (Optional)
+    ```
+
+2. Build the Docker image: `docker build . --tag snapcraft-monthly-stats`
+
+3. Run the Docker image: `docker run -ti --env-file .env.local snapcraft-monthly-stats`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sentry-sdk==0.19.4
+sentry-sdk==0.19.5
 surl==0.7
 tenacity==6.2.0


### PR DESCRIPTION
## Done

- Using the Marketo API I removed all the `null` snaps duplicates
- Avoid sending this snap until they fix their issue with the string `null` on [custom objects](https://docs.marketo.com/display/public/DOCS/Understanding+Marketo+Custom+Objects).
- Improve README
- Update sentry-sdk dependency to 0.19.5

Fixes https://github.com/canonical-web-and-design/snapcraft-monthly-stats-email/issues/10

## QA

1. Pull the branch
2. Ask for the `.env.local` file secrets
3. Docker build: `docker build . --tag test`
4. Docker run: `docker run -ti --env-file .env.local test`
